### PR TITLE
New backends - Athena and Databricks

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -568,7 +568,7 @@ outputs:
         - pip
       imports:
         - ibis
-        - ibis.backends.trino
+        - ibis.backends.athena
       commands:
         - pip check
 
@@ -592,7 +592,7 @@ outputs:
         - pip
       imports:
         - ibis
-        - ibis.backends.trino
+        - ibis.backends.databricks
       commands:
         - pip check
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -547,6 +547,54 @@ outputs:
       commands:
         - pip check
 
+  - name: ibis-athena
+    version: {{ version }}
+
+    build:
+      noarch: python
+
+    requirements:
+      host:
+        - python {{ python_min }}
+      run:
+        - python >={{ python_min }}
+        - {{ pin_subpackage(name + '-core', exact=True) }}
+        - pyathena
+        - s3fs
+
+    test:
+      requires:
+        - python {{ python_min }}
+        - pip
+      imports:
+        - ibis
+        - ibis.backends.trino
+      commands:
+        - pip check
+
+  - name: ibis-databricks
+    version: {{ version }}
+
+    build:
+      noarch: python
+
+    requirements:
+      host:
+        - python {{ python_min }}
+      run:
+        - python >={{ python_min }}
+        - {{ pin_subpackage(name + '-core', exact=True) }}
+        - databricks-sql-connector
+
+    test:
+      requires:
+        - python {{ python_min }}
+        - pip
+      imports:
+        - ibis
+        - ibis.backends.trino
+      commands:
+        - pip check
 
 about:
   license: Apache-2.0


### PR DESCRIPTION
[Latest Release](https://github.com/ibis-project/ibis/releases/tag/10.0.0) introduces new Backends for [Athena](https://github.com/ibis-project/ibis/pull/10631/files) and [Databricks](https://github.com/ibis-project/ibis/pull/10223/files).

Build seems work correctly, but the output validation will need to be updated - https://conda-forge.org/docs/maintainer/infrastructure/#output-validation-and-feedstock-tokens.